### PR TITLE
Remove deprecated onBackPressed

### DIFF
--- a/flowLib/src/main/java/net/globulus/easyflows/FlowActivity.kt
+++ b/flowLib/src/main/java/net/globulus/easyflows/FlowActivity.kt
@@ -20,7 +20,7 @@ open class FlowActivity : AppCompatActivity(), Checklist {
         onBackPressedDispatcher.addCallback(this) {
             isEnabled = false
             try {
-                onBackPressed()
+                onBackPressedCompat()
             } finally {
                 isEnabled = !isFinishing
             }
@@ -32,9 +32,8 @@ open class FlowActivity : AppCompatActivity(), Checklist {
         EventBus.getDefault().unregister(this)
     }
 
-    @Deprecated("Deprecated in Java")
-    override fun onBackPressed() {
-        super.onBackPressed()
+    protected open fun onBackPressedCompat() {
+        onBackPressedDispatcher.onBackPressed()
         handleFinish()
     }
 


### PR DESCRIPTION
Removes the deprecated onBackPressed() override and introduces onBackPressedCompat() as the new protected extension point for child activities.

Any child activity that previously overrode onBackPressed() should now override onBackPressedCompat() instead.